### PR TITLE
Add support for PES frames with a specified packet length. Currently,…

### DIFF
--- a/mpegts/mpegts/mpegts_demuxer.cpp
+++ b/mpegts/mpegts/mpegts_demuxer.cpp
@@ -114,7 +114,7 @@ int MpegTsDemuxer::decode(SimpleBuffer *in, TsFrame *&out)
                 }
                 
                 if(_ts_frames[ts_header.pid]->expected_pes_packet_length != 0 && _ts_frames[ts_header.pid]->_data->size() + 188 - in->pos() - pos > _ts_frames[ts_header.pid]->expected_pes_packet_length) {
-                    _ts_frames[ts_header.pid]->_data->append(in->data() + in->pos(), _ts_frames[ts_header.pid]->expectedPESLength - _ts_frames[ts_header.pid]->_data->size());
+                    _ts_frames[ts_header.pid]->_data->append(in->data() + in->pos(), _ts_frames[ts_header.pid]->expected_pes_packet_length - _ts_frames[ts_header.pid]->_data->size());
                 } else {
                     _ts_frames[ts_header.pid]->_data->append(in->data() + in->pos(), 188 - in->pos() - pos);
                 }

--- a/mpegts/mpegts/mpegts_demuxer.cpp
+++ b/mpegts/mpegts/mpegts_demuxer.cpp
@@ -95,6 +95,7 @@ int MpegTsDemuxer::decode(SimpleBuffer *in, TsFrame *&out)
 
                     pes_header.decode(in);
                     _ts_frames[ts_header.pid]->stream_id = pes_header.stream_id;
+                    _ts_frames[ts_header.pid]->expected_pes_packet_length = pes_header.pes_packet_length;
                     if (pes_header.pts_dts_flags == 0x02) {
                         _ts_frames[ts_header.pid]->pts = _ts_frames[ts_header.pid]->dts = read_pts(in);
                     } else if (pes_header.pts_dts_flags == 0x03) {
@@ -111,7 +112,13 @@ int MpegTsDemuxer::decode(SimpleBuffer *in, TsFrame *&out)
                         break;
                     }
                 }
-                _ts_frames[ts_header.pid]->_data->append(in->data() + in->pos(), 188 - in->pos() - pos);
+                
+                if(_ts_frames[ts_header.pid]->expected_pes_packet_length != 0 && _ts_frames[ts_header.pid]->_data->size() + 188 - in->pos() - pos > _ts_frames[ts_header.pid]->expected_pes_packet_length) {
+                    _ts_frames[ts_header.pid]->_data->append(in->data() + in->pos(), _ts_frames[ts_header.pid]->expectedPESLength - _ts_frames[ts_header.pid]->_data->size());
+                } else {
+                    _ts_frames[ts_header.pid]->_data->append(in->data() + in->pos(), 188 - in->pos() - pos);
+                }
+                
             }
         } else if (_pcr_id != 0 && _pcr_id == ts_header.pid) {
             AdaptationFieldHeader adapt_field;

--- a/mpegts/mpegts/ts_packet.cpp
+++ b/mpegts/mpegts/ts_packet.cpp
@@ -6,6 +6,7 @@
 TsFrame::TsFrame()
     : completed(false)
     , pid(0)
+    , expected_pes_packet_length(0)
 {
     _data.reset(new SimpleBuffer);
 }
@@ -14,6 +15,7 @@ TsFrame::TsFrame(uint8_t st)
     : stream_type(st)
     , completed(false)
     , pid(0)
+    , expected_pes_packet_length(0)
 {
     _data.reset(new SimpleBuffer);
 }
@@ -27,6 +29,7 @@ void TsFrame::reset()
 {
     pid = 0;
     completed = false;
+    expected_pes_packet_length = 0;
     _data.reset(new SimpleBuffer);
 }
 

--- a/mpegts/mpegts/ts_packet.h
+++ b/mpegts/mpegts/ts_packet.h
@@ -33,6 +33,7 @@ public:
     uint8_t stream_type;
     uint8_t stream_id;
     uint16_t pid;
+    uint16_t expected_pes_packet_length;
     bool completed;
 };
 


### PR DESCRIPTION
 Currently, when receiving such a frame it is possible to append errouneous data to the end of it.